### PR TITLE
change: throw an exception when the dependency type is not implemented

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,8 @@ jobs:
           channel: 'stable'
       - run: flutter pub get
       - run: dart format --fix .
-      - run: flutter analyze
-      - run: flutter test --coverage
+      - run: dart analyze
+      - run: dart test --coverage
       - name: Setup LCOV
         uses: hrishikesh-kadam/setup-lcov@v1
       - name: Report code coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,13 @@ jobs:
       - run: dart pub get
       - run: dart format --fix .
       - run: dart analyze
-      - run: dart test --coverage ./coverage
-      - name: Generate LCOV report
-        run: genhtml -o coverage --show-details --highlight --ignore-errors source --legend coverage/lcov.info
-
+      - run: flutter test --coverage 
+      - name: Setup LCOV
+        uses: hrishikesh-kadam/setup-lcov@v1
       - name: Report code coverage
         uses: zgosalvez/github-actions-report-lcov@v3
+        with:
+          coverage-files: coverage/lcov*.info
+          artifact-name: code-coverage-report
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          update-comment: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,16 +17,12 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-      - run: flutter pub get
+      - run: dart pub get
       - run: dart format --fix .
       - run: dart analyze
-      - run: dart test --coverage
-      - name: Setup LCOV
-        uses: hrishikesh-kadam/setup-lcov@v1
+      - run: dart test --coverage ./coverage
+      - name: Generate LCOV report
+        run: genhtml -o coverage --show-details --highlight --ignore-errors source --legend coverage/lcov.info
+
       - name: Report code coverage
         uses: zgosalvez/github-actions-report-lcov@v3
-        with:
-          coverage-files: coverage/lcov*.info
-          artifact-name: code-coverage-report
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          update-comment: true

--- a/lib/src/generators/getit/dependency_config_factory.dart
+++ b/lib/src/generators/getit/dependency_config_factory.dart
@@ -2,12 +2,12 @@ import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:source_gen/source_gen.dart';
-import 'package:stacked_shared/stacked_shared.dart';
 import 'package:stacked_generator/import_resolver.dart';
 import 'package:stacked_generator/src/generators/getit/dependency_config/factory_dependency.dart';
 import 'package:stacked_generator/src/generators/getit/dependency_config/presolve_singleton_dependency.dart';
 import 'package:stacked_generator/src/generators/getit/dependency_config/singleton_dependency.dart';
 import 'package:stacked_generator/src/generators/getit/stacked_locator_parameter_resolver.dart';
+import 'package:stacked_shared/stacked_shared.dart';
 
 import '../../../utils.dart';
 import 'dependency_config/dependency_config.dart';
@@ -125,7 +125,8 @@ class DependencyConfigFactory {
         abstractedImport: abstractedImport,
         environments: environments,
       );
-    } else {
+    } else if (dependencyReader
+        .instanceOf(const TypeChecker.fromRuntime(FactoryWithParam))) {
       final Set<FactoryParameter> clazzParams = {};
       var params = constructor?.parameters;
       if (params?.isNotEmpty == true && constructor != null) {
@@ -142,6 +143,10 @@ class DependencyConfigFactory {
           abstractedImport: abstractedImport,
           environments: environments,
           params: clazzParams);
+    } else {
+      throw UnimplementedError(
+        'This Dependency ${dependencyReader.typeValue} is not implemented yet upgrading stacked_generator package to the latest version may fix the issue',
+      );
     }
   }
 }

--- a/test/getit/unit_test/factory_test.dart
+++ b/test/getit/unit_test/factory_test.dart
@@ -11,8 +11,7 @@ void main() {
     setUp(StackedLocator.instance.reset);
     test('When forget to register factory, Should throw AssertionError',
         () async {
-      expect(
-          () => factoryLocator<DumpService>(), throwsA(isA<AssertionError>()));
+      expect(() => factoryLocator<DumpService>(), throwsA(isA<StateError>()));
     });
     test('When register factory, Should returnsNormally', () async {
       setupFactoryLocator();
@@ -23,8 +22,7 @@ void main() {
         'When register factory with type, Should call it by the type not the implementation',
         () async {
       setupFactorywithtypeLocator();
-      expect(
-          () => factoryLocator<DumpService>(), throwsA(isA<AssertionError>()));
+      expect(() => factoryLocator<DumpService>(), throwsA(isA<StateError>()));
       expect(() => factoryLocator<AbstractDumpService>(), returnsNormally);
     });
     test(

--- a/test/getit/unit_test/singleton_test.dart
+++ b/test/getit/unit_test/singleton_test.dart
@@ -11,8 +11,7 @@ void main() {
     setUp(StackedLocator.instance.reset);
     test('When forget to register singleton, Should throw AssertionError',
         () async {
-      expect(() => singletonLocator<DumpService>(),
-          throwsA(isA<AssertionError>()));
+      expect(() => singletonLocator<DumpService>(), throwsA(isA<StateError>()));
     });
     test('When register singleton, Should returnsNormally', () async {
       setupSingletonLocator();
@@ -24,8 +23,7 @@ void main() {
         () async {
       setupSingletonWithTypeLocator();
 
-      expect(() => singletonLocator<DumpService>(),
-          throwsA(isA<AssertionError>()));
+      expect(() => singletonLocator<DumpService>(), throwsA(isA<StateError>()));
       expect(() => singletonLocator<AbstractDumpService>(), returnsNormally);
     });
     test(


### PR DESCRIPTION
Throw an exception when the dependency type is not implemented yet instead of using FactoryWithParam as a backup type to prevent future issues(like [this](https://github.com/Stacked-Org/stacked/issues/984)) when adding a new dependency type.