### PR TITLE
Generate proper route  names when using custom names

### DIFF
--- a/lib/src/generators/router_2/code_builder/root_router_builder.dart
+++ b/lib/src/generators/router_2/code_builder/root_router_builder.dart
@@ -282,6 +282,20 @@ Expression getUrlParamAssignment(ParamConfig p) {
   }
 }
 
+Expression getConstructorParamAssignment(ParamConfig p) {
+  if (p.isPathParam) {
+    return refer('data').property('pathParams').property(p.getterMethodName).call([
+      literalString(p.paramName),
+      if (p.defaultValueCode != null && p.type.isNullable) refer(p.defaultValueCode!),
+    ]);
+  } else {
+    return refer('data').property('pathParams').property(p.getterMethodName).call([
+      literalString(p.paramName),
+      if (p.defaultValueCode != null && p.type.isNullable) refer(p.defaultValueCode!),
+    ]);
+  }
+}
+
 Iterable<Object> buildRoutes(List<RouteConfig> routes, {Reference? parent}) =>
     routes.map(
       (r) {

--- a/lib/src/generators/router_common/models/route_config.dart
+++ b/lib/src/generators/router_common/models/route_config.dart
@@ -1,6 +1,8 @@
 import 'package:code_builder/code_builder.dart';
+import 'package:dart_style/dart_style.dart';
 
 import '../../../../utils.dart';
+import '../../router_2/code_builder/root_router_builder.dart';
 import 'importable_type.dart';
 import 'route_parameter_config.dart';
 import 'router_config.dart';
@@ -206,12 +208,11 @@ class RouteConfig {
   Iterable<String> _extractViewConstructerParametersNames() {
     return parameters.map<String>((param) {
       String getterName;
+      final emitter = DartEmitter();
       if (param.isPathParam) {
-        getterName =
-            "data.pathParams['${param.paramName}'].${param.getterName}(${param.defaultValueCode != null ? '${param.defaultValueCode}' : ''})";
+        getterName = getConstructorParamAssignment(param).code.accept(emitter).toString();
       } else if (param.isQueryParam) {
-        getterName =
-            "data.queryParams['${param.paramName}'].${param.getterName}(${param.defaultValueCode != null ? '${param.defaultValueCode}' : ''})";
+        getterName = getConstructorParamAssignment(param).code.accept(emitter).toString();
       } else {
         getterName = "args.${param.name}";
       }


### PR DESCRIPTION
Issue:
When MaterialRoute is created with custom name, generator ignores custom name and create Route based on raw page value

before
`MaterialRoute(page: WorkoutListView, path: 'workout', name: 'workoutListHome'),
  MaterialRoute(page: RoutineListView, path: 'routine', name: 'routineListHome'),
`

![err2](https://github.com/Stacked-Org/generator/assets/5392781/cef4bb8c-30e2-4132-b121-53d228624f79)

after fix

![image](https://github.com/Stacked-Org/generator/assets/5392781/b2f58796-c637-4328-ba51-024c404ee7b1)

