### PR TITLE
chore(deps): Updated freezed: 3.0.6, freezed_annotation: 3.0.0, source_gen: 2.0.0, dart_style: 3.0.1

### DIFF
--- a/lib/src/generators/router/generator/router_generator.dart
+++ b/lib/src/generators/router/generator/router_generator.dart
@@ -62,7 +62,8 @@ class RouterGenerator implements BaseGenerator {
         ..body.addAll([...parsedClasses, navigationExtensionClassBuilder]),
     );
 
-    return DartFormatter().format('${library.accept(emitter)}');
+    return DartFormatter(languageVersion: DartFormatter.latestLanguageVersion)
+        .format('${library.accept(emitter)}');
   }
 
   /// The classes are:

--- a/lib/src/generators/router_2/code_builder/library_builder.dart
+++ b/lib/src/generators/router_2/code_builder/library_builder.dart
@@ -115,5 +115,6 @@ String generateLibrary(
       ]),
   );
 
-  return DartFormatter().format(library.accept(emitter).toString());
+  return DartFormatter(languageVersion: DartFormatter.latestLanguageVersion)
+      .format(library.accept(emitter).toString());
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   stacked_shared: ^1.3.0
   # Removing this will cause issues when publish the package
   analyzer: ^6.3.0
-  dart_style: ^2.3.4
+  dart_style: ^3.0.1
   code_builder: ^4.3.0
   collection: ^1.16.0
   freezed_annotation: ^3.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   build: ^2.2.1
   path: ^1.8.0
   recase: ^4.0.0
-  source_gen: ^1.2.7
+  source_gen: ^2.0.0
   meta: ^1.10.0
   logger: ^1.1.0
   stacked_shared: ^1.3.0
@@ -19,7 +19,7 @@ dependencies:
   dart_style: ^2.3.4
   code_builder: ^4.3.0
   collection: ^1.16.0
-  freezed_annotation: ^2.2.0
+  freezed_annotation: ^3.0.0
   json_annotation: ^4.8.0
   xdg_directories: ^1.0.4
 
@@ -28,6 +28,6 @@ dev_dependencies:
   test: ^1.20.1
   build_test: ^2.1.5
   flutter_lints: ^3.0.1
-  freezed: ^2.3.2
+  freezed: ^3.0.6
   json_serializable: ^6.6.1
   mockito: ^5.4.4

--- a/test/helpers/class_extension.dart
+++ b/test/helpers/class_extension.dart
@@ -6,7 +6,9 @@ extension SpecExtension on Spec {
     final library = Library((b) => b..body.add(this));
 
     final emitter = DartEmitter.scoped();
-    final result = DartFormatter().format('${library.accept(emitter)}');
+    final result =
+        DartFormatter(languageVersion: DartFormatter.latestLanguageVersion)
+            .format('${library.accept(emitter)}');
     //print(result);
     return result;
   }
@@ -17,7 +19,9 @@ extension SpecsExtension on Iterable<Spec> {
     final library = Library((b) => b..body.addAll(this));
 
     final emitter = DartEmitter.scoped();
-    final result = DartFormatter().format('${library.accept(emitter)}');
+    final result =
+        DartFormatter(languageVersion: DartFormatter.latestLanguageVersion)
+            .format('${library.accept(emitter)}');
 
     return result;
   }
@@ -28,7 +32,9 @@ extension ListExpressionExtension on Iterable<Expression> {
     final library = Library((b) => b..body.addAll(this));
 
     final emitter = DartEmitter.scoped();
-    final result = DartFormatter().format('${library.accept(emitter)}');
+    final result =
+        DartFormatter(languageVersion: DartFormatter.latestLanguageVersion)
+            .format('${library.accept(emitter)}');
 
     return result;
   }


### PR DESCRIPTION
### Description
This PR updates the following dependencies to their latest compatible versions:
- `freezed` → 3.0.6
- `freezed_annotation` → 3.0.0
- `source_gen` → 2.0.0
- `dart_style` → 3.0.1

### Motivation
The primary motivation for this upgrade is compatibility. `generator` was constrained to `freezed_annotation: ^2.2.0`. However, another project that depends on this package requires `freezed_annotation: ^3.0.0` or higher. This version mismatch caused dependency resolution conflicts, blocking integration and development efforts.

### Details
- Upgraded `freezed` and `freezed_annotation` to ensure compatibility with projects requiring version 3.x.
- Updated `source_gen` and `dart_style` to meet the new peer dependency requirements of `freezed` and improve code generation stability.
- Verified that all code generation and build_runner tasks complete successfully with the new versions.
- Increased compatibility: This change unblocks downstream projects that require `freezed_annotation` v3.x.
- Future-proofing: Staying up-to-date with the latest stable releases reduces technical debt and improves maintainability.
- No breaking changes: All existing functionality remains intact; only dependency versions are updated.