### PR TITLE
refactor: migrate to analyzer element2 API and update dependencies

### DIFF
--- a/lib/import_resolver.dart
+++ b/lib/import_resolver.dart
@@ -1,30 +1,31 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:path/path.dart' as p;
 
 class ImportResolver {
-  final List<LibraryElement> libs;
+  final List<LibraryElement2> libs;
   final String targetFilePath;
 
   const ImportResolver(this.libs, this.targetFilePath);
 
-  String? resolve(Element? element) {
+  String? resolve(Element2? element) {
     // return early if source is null or element is a core type
-    if (element?.source == null || _isCoreDartType(element)) {
+    if (element?.firstFragment.libraryFragment?.source == null ||
+        _isCoreDartType(element)) {
       return null;
     }
 
     for (var lib in libs) {
       if (_isCoreDartType(lib)) continue;
 
-      if (lib.exportNamespace.definedNames.keys.contains(element?.name)) {
-        final package = lib.source.uri.pathSegments.first;
+      if (lib.exportNamespace.definedNames2.keys.contains(element?.firstFragment.name2)) {
+        final package = lib.firstFragment.libraryFragment?.source.uri.pathSegments.first;
         if (targetFilePath.startsWith(RegExp('^$package/'))) {
           return p.posix
-              .relative(element?.source?.uri.path ?? '', from: targetFilePath)
+              .relative(element?.firstFragment.libraryFragment?.source.uri.path ?? '', from: targetFilePath)
               .replaceFirst('../', '');
         } else {
-          return element?.source?.uri.toString();
+          return element?.firstFragment.libraryFragment?.source.uri.toString();
         }
       }
     }
@@ -32,13 +33,14 @@ class ImportResolver {
     return null;
   }
 
-  bool _isCoreDartType(Element? element) {
-    return element?.source?.fullName == 'dart:core';
+  bool _isCoreDartType(Element2? element) {
+    return element?.firstFragment.libraryFragment?.source.fullName ==
+        'dart:core';
   }
 
   Set<String> resolveAll(DartType type) {
     final imports = <String>{};
-    final resolvedValue = resolve(type.element);
+    final resolvedValue = resolve(type.element3);
     if (resolvedValue != null) {
       imports.add(resolvedValue);
     }
@@ -50,7 +52,7 @@ class ImportResolver {
     final imports = <String>{};
     if (typeToCheck is ParameterizedType) {
       for (DartType type in typeToCheck.typeArguments) {
-        final resolvedValue = resolve(type.element);
+        final resolvedValue = resolve(type.element3);
         if (resolvedValue != null) {
           imports.add(resolvedValue);
         }

--- a/lib/src/generators/bottomsheets/resolve/bottomsheet_config_resolver.dart
+++ b/lib/src/generators/bottomsheets/resolve/bottomsheet_config_resolver.dart
@@ -1,5 +1,5 @@
 import 'package:analyzer/dart/constant/value.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:stacked_generator/import_resolver.dart';
 import 'package:stacked_generator/src/generators/bottomsheets/bottomsheet_config.dart';
@@ -21,7 +21,7 @@ class BottomsheetConfigResolver {
       final bottomsheetClassType =
           bottomsheetReader.read('classType').typeValue;
 
-      final classElement = bottomsheetClassType.element as ClassElement?;
+      final classElement = bottomsheetClassType.element3 as ClassElement2?;
 
       // Get the import of the class type that's defined for the bottomSheet
       final import = importResolver.resolve(classElement!);

--- a/lib/src/generators/bottomsheets/resolve/stacked_bottomsheet_generator.dart
+++ b/lib/src/generators/bottomsheets/resolve/stacked_bottomsheet_generator.dart
@@ -1,24 +1,25 @@
 import 'dart:async';
 
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:build/build.dart';
 import 'package:source_gen/source_gen.dart';
-import 'package:stacked_shared/stacked_shared.dart';
 import 'package:stacked_generator/import_resolver.dart';
 import 'package:stacked_generator/src/generators/bottomsheets/generate/bottomsheet_class_generator.dart';
+import 'package:stacked_shared/stacked_shared.dart';
 
 import 'bottomsheet_config_resolver.dart';
 
 class StackedBottomsheetGenerator extends GeneratorForAnnotation<StackedApp> {
   @override
   FutureOr<String> generateForAnnotatedElement(
-    Element element,
+    Element2 element,
     ConstantReader annotation,
     BuildStep buildStep,
   ) async {
     final bottomsheetResolver = BottomsheetConfigResolver();
     final libs = await buildStep.resolver.libraries.toList();
-    final importResolver = ImportResolver(libs, element.source?.uri.path ?? '');
+    final importResolver = ImportResolver(
+        libs, element.firstFragment.libraryFragment?.source.uri.path ?? '');
 
     /// If the bottomsheets parameter is not mentioned in the StackedApp
     /// return empty string

--- a/lib/src/generators/dialogs/resolve/dialog_config_resolver.dart
+++ b/lib/src/generators/dialogs/resolve/dialog_config_resolver.dart
@@ -1,5 +1,5 @@
 import 'package:analyzer/dart/constant/value.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:stacked_generator/import_resolver.dart';
 import 'package:stacked_generator/src/generators/dialogs/dialog_config.dart';
@@ -21,7 +21,7 @@ class DialogConfigResolver {
       // Get the type of the dialog that we want to register
       final dialogClassType = dialogReader.read('classType').typeValue;
 
-      final classElement = dialogClassType.element as ClassElement?;
+      final classElement = dialogClassType.element3 as ClassElement2?;
 
       // Get the import of the class type that's defined for the dialog
       final import = importResolver.resolve(classElement!);

--- a/lib/src/generators/dialogs/resolve/stacked_dialog_generator.dart
+++ b/lib/src/generators/dialogs/resolve/stacked_dialog_generator.dart
@@ -1,24 +1,25 @@
 import 'dart:async';
 
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:build/build.dart';
 import 'package:source_gen/source_gen.dart';
-import 'package:stacked_shared/stacked_shared.dart';
 import 'package:stacked_generator/import_resolver.dart';
 import 'package:stacked_generator/src/generators/dialogs/generate/dialog_class_generator.dart';
+import 'package:stacked_shared/stacked_shared.dart';
 
 import 'dialog_config_resolver.dart';
 
 class StackedDialogGenerator extends GeneratorForAnnotation<StackedApp> {
   @override
   FutureOr<String> generateForAnnotatedElement(
-    Element element,
+    Element2 element,
     ConstantReader annotation,
     BuildStep buildStep,
   ) async {
     final dialogResolver = DialogConfigResolver();
     final libs = await buildStep.resolver.libraries.toList();
-    final importResolver = ImportResolver(libs, element.source?.uri.path ?? '');
+    final importResolver = ImportResolver(
+        libs, element.firstFragment.libraryFragment?.source.uri.path ?? '');
 
     /// If the dialogs parameter is not mentioned in the StackedApp
     /// return empty string

--- a/lib/src/generators/exceptions/invalid_generator_input_exception.dart
+++ b/lib/src/generators/exceptions/invalid_generator_input_exception.dart
@@ -1,9 +1,9 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 
 class InvalidGeneratorInputException implements Exception {
   final String message;
   final String? todo;
-  final Element? element;
+  final Element2? element;
   const InvalidGeneratorInputException(this.message, {this.todo, this.element});
 
   @override

--- a/lib/src/generators/forms/field_config.dart
+++ b/lib/src/generators/forms/field_config.dart
@@ -1,6 +1,6 @@
 // ignore_for_file: unnecessary_this
 
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 
 /// Described a single field to be generated.
 ///
@@ -55,13 +55,15 @@ class ExecutableElementData {
   });
 
   factory ExecutableElementData.fromExecutableElement(
-      ExecutableElement executableElement) {
+      ExecutableElement2 executableElement) {
     return ExecutableElementData(
-        returnType: executableElement.declaration.returnType.toString(),
-        enclosingElementName: executableElement.enclosingElementName,
-        hasEnclosingElementName: executableElement.hasEnclosingElementName,
-        validatorName: executableElement.validatorName,
-        validatorPath: executableElement.validatorPath);
+      returnType: executableElement.firstFragment.element.returnType.toString(),
+      enclosingElementName: executableElement.enclosingElement2?.name3,
+      hasEnclosingElementName:
+          executableElement.enclosingElement2?.name3 != null,
+      validatorName: executableElement.validatorName,
+      validatorPath: executableElement.validatorPath,
+    );
   }
 }
 
@@ -76,11 +78,12 @@ extension ListOfFieldConfigs on List<FieldConfig> {
       this.whereType<DropdownFieldConfig>().map((t) => t).toList();
 }
 
-extension ExecutableElementDataExtension on ExecutableElement? {
-  String? get validatorPath => this?.source.uri.toString();
+extension ExecutableElementDataExtension on ExecutableElement2? {
+  String? get validatorPath =>
+      this?.firstFragment.libraryFragment.source.uri.toString();
   String? get validatorName => hasEnclosingElementName
-      ? '$enclosingElementName.${this?.name}'
-      : this?.name;
+      ? '$enclosingElementName.${this?.name3}'
+      : this?.name3;
   bool get hasEnclosingElementName => enclosingElementName != null;
-  String? get enclosingElementName => this?.enclosingElement.name;
+  String? get enclosingElementName => this?.enclosingElement2?.name3;
 }

--- a/lib/src/generators/forms/form_builder.dart
+++ b/lib/src/generators/forms/form_builder.dart
@@ -56,6 +56,7 @@ class FormBuilder with StringBufferUtils {
   }
 
   FormBuilder addAnnotationOptions() {
+    if (fields.onlyTextFieldConfigs.isEmpty) return this;
     newLine();
     writeLine(
       "const bool _autoTextFieldValidation = $autoTextFieldValidation;",
@@ -169,7 +170,7 @@ class FormBuilder with StringBufferUtils {
   FormBuilder addGetTextEditingController() {
     if (fields.onlyTextFieldConfigs.isEmpty) return this;
     newLine();
-    writeLine(''' 
+    writeLine('''
       TextEditingController _getFormTextEditingController(
         String key, {
         String? initialValue,
@@ -220,7 +221,7 @@ class FormBuilder with StringBufferUtils {
     if (fields.onlyTextFieldConfigs.isEmpty) return this;
 
     newLine();
-    writeLine(''' 
+    writeLine('''
       FocusNode _getFormFocusNode(String key) {
         if (_${viewName}FocusNodes.containsKey(key)) {
         return _${viewName}FocusNodes[key]!;}
@@ -246,9 +247,11 @@ class FormBuilder with StringBufferUtils {
     }
 
     newLine();
-    writeLine(
-      "_updateFormData(model, forceValidate: _autoTextFieldValidation);",
-    );
+    if (fields.onlyTextFieldConfigs.isNotEmpty) {
+      writeLine(
+        "_updateFormData(model, forceValidate: _autoTextFieldValidation);",
+      );
+    }
     writeLine('}');
     newLine();
 
@@ -269,9 +272,11 @@ class FormBuilder with StringBufferUtils {
     }
 
     newLine();
-    writeLine(
-      "_updateFormData(model, forceValidate: _autoTextFieldValidation);",
-    );
+    if (fields.onlyTextFieldConfigs.isNotEmpty) {
+      writeLine(
+        "_updateFormData(model, forceValidate: _autoTextFieldValidation);",
+      );
+    }
     writeLine('}');
     newLine();
     return this;
@@ -385,8 +390,13 @@ class FormBuilder with StringBufferUtils {
 
     newLine();
     writeLine("""bool get isFormValid {
-      if (!_autoTextFieldValidation) this.validateForm();
-
+    """);
+    if (fields.onlyTextFieldConfigs.isNotEmpty) {
+      writeLine("""
+    if (!_autoTextFieldValidation) this.validateForm();
+""");
+    }
+    writeLine("""
       return !hasAnyValidationMessage;
     }""");
 
@@ -482,12 +492,13 @@ class FormBuilder with StringBufferUtils {
                 ${_getFormKeyName(caseName)}: selectedDate}),
               );
             }
-
-            if (_autoTextFieldValidation) {
-              this.validateForm();
-            }
-          }
     ''');
+      if (fields.onlyTextFieldConfigs.isNotEmpty) {
+        writeLine(
+          "if (_autoTextFieldValidation) this.validateForm();",
+        );
+      }
+      writeLine('}');
       newLine();
     }
 
@@ -499,12 +510,13 @@ class FormBuilder with StringBufferUtils {
             this.setData(
               this.formValueMap..addAll({${_getFormKeyName(caseName)}: ${caseName.camelCase}}),
             );
-
-            if (_autoTextFieldValidation) {
-              this.validateForm();
-            }
-          }
     ''');
+      if (fields.onlyTextFieldConfigs.isNotEmpty) {
+        writeLine(
+          "if (_autoTextFieldValidation) this.validateForm();",
+        );
+      }
+      writeLine('}');
       newLine();
     }
 
@@ -513,7 +525,7 @@ class FormBuilder with StringBufferUtils {
     for (final field in fields) {
       final caseName = ReCase(field.name);
       writeLine(
-          'set${caseName.pascalCase}ValidationMessage(String? validationMessage) => this.fieldsValidationMessages[${_getFormKeyName(caseName)}] = validationMessage;');
+          'void set${caseName.pascalCase}ValidationMessage(String? validationMessage) => this.fieldsValidationMessages[${_getFormKeyName(caseName)}] = validationMessage;');
     }
 
     // Write out the clearForm method

--- a/lib/src/generators/forms/stacked_form_generator.dart
+++ b/lib/src/generators/forms/stacked_form_generator.dart
@@ -1,27 +1,29 @@
 import 'dart:async';
 
 import 'package:analyzer/dart/constant/value.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:build/build.dart';
 import 'package:source_gen/source_gen.dart';
-import 'package:stacked_shared/stacked_shared.dart';
 import 'package:stacked_generator/import_resolver.dart';
 import 'package:stacked_generator/src/generators/forms/field_config.dart';
 import 'package:stacked_generator/src/generators/forms/form_view_config.dart';
 import 'package:stacked_generator/src/generators/forms/stacked_form_content_generator.dart';
+import 'package:stacked_shared/stacked_shared.dart';
 
 class StackedFormGenerator extends GeneratorForAnnotation<FormView> {
   @override
   FutureOr<String> generateForAnnotatedElement(
     // ignore: avoid_renaming_method_parameters
-    Element classForAnnotation,
+    Element2 classForAnnotation,
     // ignore: avoid_renaming_method_parameters
     ConstantReader formView,
     BuildStep buildStep,
   ) async {
     var libs = await buildStep.resolver.libraries.toList();
-    var importResolver =
-        ImportResolver(libs, classForAnnotation.source?.uri.path ?? '');
+    var importResolver = ImportResolver(
+        libs,
+        classForAnnotation.firstFragment.libraryFragment?.source.uri.path ??
+            '');
 
     final viewName = classForAnnotation.displayName;
 
@@ -82,11 +84,11 @@ FieldConfig _readTextFieldConfig({
 }) {
   final String name = (fieldReader.peek('name')?.stringValue) ?? '';
   final String? initialValue = (fieldReader.peek('initialValue')?.stringValue);
-  final ExecutableElement? validatorFunction =
-      (fieldReader.peek('validator')?.objectValue)?.toFunctionValue();
-  final ExecutableElement? customTextEditingController =
+  final ExecutableElement2? validatorFunction =
+      (fieldReader.peek('validator')?.objectValue)?.toFunctionValue2();
+  final ExecutableElement2? customTextEditingController =
       (fieldReader.peek('customTextEditingController')?.objectValue)
-          ?.toFunctionValue();
+          ?.toFunctionValue2();
   return TextFieldConfig(
     name: name,
     initialValue: initialValue,

--- a/lib/src/generators/getit/dependency_config_factory.dart
+++ b/lib/src/generators/getit/dependency_config_factory.dart
@@ -1,5 +1,5 @@
 import 'package:analyzer/dart/constant/value.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:stacked_generator/import_resolver.dart';
@@ -32,7 +32,7 @@ class DependencyConfigFactory {
     final DartType? dependencyAbstractedClassType =
         dependencyReader.peek('asType')?.typeValue;
 
-    final classElement = dependencyClassType.element as ClassElement?;
+    final classElement = dependencyClassType.element3 as ClassElement2?;
 
     throwIf(
       classElement == null,
@@ -51,7 +51,7 @@ class DependencyConfigFactory {
     final import = importResolver.resolve(classElement!);
 
     final abstractedClassElement =
-        dependencyAbstractedClassType?.element as ClassElement?;
+        dependencyAbstractedClassType?.element3 as ClassElement2?;
 
     final abstractedImport = importResolver.resolve(abstractedClassElement);
 
@@ -62,7 +62,7 @@ class DependencyConfigFactory {
         : null;
 
     // NOTE: This can be used for actual dependency inject. We do service location instead.
-    final constructor = classElement.unnamedConstructor;
+    final constructor = classElement.unnamedConstructor2;
 
     if (dependencyReader.instanceOf(const TypeChecker.fromRuntime(Factory))) {
       return FactoryDependency(
@@ -77,7 +77,7 @@ class DependencyConfigFactory {
         .instanceOf(const TypeChecker.fromRuntime(Singleton))) {
       final ConstantReader? resolveUsing =
           dependencyReader.peek('resolveUsing');
-      final resolveObject = resolveUsing?.objectValue.toFunctionValue();
+      final resolveObject = resolveUsing?.objectValue.toFunctionValue2();
 
       return SingletonDependency(
           instanceName: instanceName,
@@ -91,7 +91,7 @@ class DependencyConfigFactory {
         .instanceOf(const TypeChecker.fromRuntime(LazySingleton))) {
       final ConstantReader? resolveUsing =
           dependencyReader.peek('resolveUsing');
-      final resolveObject = resolveUsing?.objectValue.toFunctionValue();
+      final resolveObject = resolveUsing?.objectValue.toFunctionValue2();
 
       return LazySingletonDependency(
           instanceName: instanceName,
@@ -106,7 +106,7 @@ class DependencyConfigFactory {
         .instanceOf(const TypeChecker.fromRuntime(Presolve))) {
       final ConstantReader? presolveUsing =
           dependencyReader.peek('presolveUsing');
-      final presolveObject = presolveUsing?.objectValue.toFunctionValue();
+      final presolveObject = presolveUsing?.objectValue.toFunctionValue2();
       return PresolveSingletonDependency(
           instanceName: instanceName,
           import: import!,
@@ -128,10 +128,10 @@ class DependencyConfigFactory {
     } else if (dependencyReader
         .instanceOf(const TypeChecker.fromRuntime(FactoryWithParam))) {
       final Set<FactoryParameter> clazzParams = {};
-      var params = constructor?.parameters;
+      var params = constructor?.formalParameters;
       if (params?.isNotEmpty == true && constructor != null) {
         final paramResolver = DependencyParameterResolver(importResolver);
-        for (ParameterElement p in constructor.parameters) {
+        for (FormalParameterElement p in constructor.formalParameters) {
           clazzParams.add(paramResolver.resolve(p));
         }
       }

--- a/lib/src/generators/getit/stacked_locator_generator.dart
+++ b/lib/src/generators/getit/stacked_locator_generator.dart
@@ -1,13 +1,13 @@
 import 'dart:async';
 
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:build/build.dart';
 import 'package:source_gen/source_gen.dart';
-import 'package:stacked_shared/stacked_shared.dart';
 import 'package:stacked_generator/import_resolver.dart';
 import 'package:stacked_generator/src/generators/extensions/string_utils_extension.dart';
 import 'package:stacked_generator/src/generators/getit/stacked_locator_content_generator.dart';
 import 'package:stacked_generator/utils.dart';
+import 'package:stacked_shared/stacked_shared.dart';
 
 import 'dependency_config/dependency_config.dart';
 import 'dependency_config_factory.dart';
@@ -15,13 +15,14 @@ import 'dependency_config_factory.dart';
 class StackedLocatorGenerator extends GeneratorForAnnotation<StackedApp> {
   @override
   FutureOr<String> generateForAnnotatedElement(
-    Element element,
+    Element2 element,
     // ignore: avoid_renaming_method_parameters
     ConstantReader stackedApplication,
     BuildStep buildStep,
   ) async {
     final libs = await buildStep.resolver.libraries.toList();
-    final importResolver = ImportResolver(libs, element.source?.uri.path ?? '');
+    final importResolver = ImportResolver(
+        libs, element.firstFragment.libraryFragment?.source.uri.path ?? '');
 
     final String locatorName =
         stackedApplication.peek('locatorName')!.stringValue;

--- a/lib/src/generators/getit/stacked_locator_parameter_resolver.dart
+++ b/lib/src/generators/getit/stacked_locator_parameter_resolver.dart
@@ -1,8 +1,8 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:source_gen/source_gen.dart';
-import 'package:stacked_shared/stacked_shared.dart';
 import 'package:stacked_generator/import_resolver.dart';
 import 'package:stacked_generator/utils.dart';
+import 'package:stacked_shared/stacked_shared.dart';
 
 import 'dependency_config/factory_param_dependency.dart';
 
@@ -13,15 +13,15 @@ class DependencyParameterResolver {
 
   const DependencyParameterResolver(this._importResolver);
 
-  FactoryParameter resolve(ParameterElement parameterElement) {
+  FactoryParameter resolve(FormalParameterElement parameterElement) {
     final paramType = parameterElement.type;
 
     final isFactoryParam =
         _factoryParamChecker.hasAnnotationOfExact(parameterElement);
     return FactoryParameter(
       isFactoryParam: isFactoryParam,
-      type: toDisplayString(paramType, withNullability: true),
-      name: parameterElement.name.replaceFirst("_", ''),
+      type: toDisplayString(paramType),
+      name: parameterElement.name3?.replaceFirst("_", ''),
       isPositional: parameterElement.isPositional,
       isRequired: !parameterElement.isOptional,
       defaultValueCode: parameterElement.defaultValueCode,

--- a/lib/src/generators/logging/logger_class_content.dart
+++ b/lib/src/generators/logging/logger_class_content.dart
@@ -6,9 +6,9 @@ const String disableConsoleOutputInRelease = 'MultiLoggerList';
 const String loggerClassPrefex = '''
 // ignore_for_file: avoid_print, depend_on_referenced_packages
 
-/// Maybe this should be generated for the user as well?
-///
-/// import 'package:customer_app/services/stackdriver/stackdriver_service.dart';
+// Maybe this should be generated for the user as well?
+//
+// import 'package:customer_app/services/stackdriver/stackdriver_service.dart';
 import 'package:flutter/foundation.dart';
 import 'package:logger/logger.dart';
 ''';
@@ -30,10 +30,14 @@ class SimpleLogPrinter extends LogPrinter {
     this.showOnlyClass,
   });
 
+  final printer = PrettyPrinter(
+    levelColors: PrettyPrinter.defaultLevelColors,
+    levelEmojis: PrettyPrinter.defaultLevelEmojis,
+  );
   @override
   List<String> log(LogEvent event) {
-    var color = PrettyPrinter.defaultLevelColors[event.level];
-    var emoji = PrettyPrinter.defaultLevelEmojis[event.level];
+    var color = printer.levelColors?[event.level];
+    var emoji = printer.levelEmojis?[event.level];
     var methodName = _getMethodName();
 
     var methodNameSection =
@@ -42,9 +46,12 @@ class SimpleLogPrinter extends LogPrinter {
     var output =
         '\$emoji \$className\$methodNameSection - \${event.message}\${event.error != null ? '\\nERROR: \${event.error}\\n' : ''}\${printCallStack ? '\\nSTACKTRACE:\\n\$stackLog' : ''}';
 
-    if (exludeLogsFromClasses
-            .any((excludeClass) => className == excludeClass) ||
-        (showOnlyClass != null && className != showOnlyClass)) return [];
+    if (exludeLogsFromClasses.any(
+          (excludeClass) => className == excludeClass,
+        ) ||
+        (showOnlyClass != null && className != showOnlyClass)) {
+      return [];
+    }
 
     final pattern = RegExp('.{1,800}'); // 800 is the size of each chunk
     List<String> result = [];

--- a/lib/src/generators/logging/logger_config_resolver.dart
+++ b/lib/src/generators/logging/logger_config_resolver.dart
@@ -1,5 +1,5 @@
 import 'package:analyzer/dart/constant/value.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:stacked_generator/import_resolver.dart';
 import 'package:stacked_generator/src/generators/logging/logger_config.dart';
@@ -34,7 +34,7 @@ class LoggerConfigResolver {
   List<String> _resolveMultiLogger(List<DartObject>? multiLogger) {
     if (multiLogger != null) {
       return multiLogger
-          .map((e) => e.toTypeValue()?.getDisplayString(withNullability: false))
+          .map((e) => e.toTypeValue()?.getDisplayString())
           .where((element) => element != null)
           .toList()
           .cast<String>();
@@ -58,8 +58,8 @@ class LoggerConfigResolver {
     }
   }
 
-  ClassElement _dartOjectToElemet(DartObject obj) {
+  ClassElement2 _dartOjectToElemet(DartObject obj) {
     var dependencyReader = ConstantReader(obj).typeValue;
-    return dependencyReader.element as ClassElement;
+    return dependencyReader.element3 as ClassElement2;
   }
 }

--- a/lib/src/generators/logging/stacked_logger_generator.dart
+++ b/lib/src/generators/logging/stacked_logger_generator.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
-import 'package:analyzer/dart/element/element.dart';
-import 'package:stacked_shared/stacked_shared.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:build/build.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:stacked_generator/import_resolver.dart';
+import 'package:stacked_shared/stacked_shared.dart';
 
 import 'logger_class_generator.dart';
 import 'logger_config_resolver.dart';
@@ -12,13 +12,14 @@ import 'logger_config_resolver.dart';
 class StackedLoggerGenerator extends GeneratorForAnnotation<StackedApp> {
   @override
   FutureOr<String> generateForAnnotatedElement(
-    Element element,
+    Element2 element,
     ConstantReader annotation,
     BuildStep buildStep,
   ) async {
     var loggerResolver = LoggerConfigResolver();
     var libs = await buildStep.resolver.libraries.toList();
-    var importResolver = ImportResolver(libs, element.source?.uri.path ?? '');
+    var importResolver = ImportResolver(
+        libs, element.firstFragment.libraryFragment?.source.uri.path ?? '');
 
     final loggerConfig = await loggerResolver.resolve(
       annotation,

--- a/lib/src/generators/router/route_config/route_config_factory.dart
+++ b/lib/src/generators/router/route_config/route_config_factory.dart
@@ -1,7 +1,7 @@
 import 'package:source_gen/source_gen.dart';
-import 'package:stacked_shared/stacked_shared.dart';
 import 'package:stacked_generator/src/generators/router_common/models/importable_type.dart';
 import 'package:stacked_generator/src/generators/router_common/models/route_config.dart';
+import 'package:stacked_shared/stacked_shared.dart';
 
 import '../../router_common/models/route_parameter_config.dart';
 import 'adaptive_route_config.dart';
@@ -74,18 +74,18 @@ class RouteConfigFactory {
       final function = stackedRoute
           .peek('transitionsBuilder')
           ?.objectValue
-          .toFunctionValue();
+          .toFunctionValue2();
 
       ResolvedType? customTransitionBuilder;
       if (function != null) {
         final displayName = function.displayName.replaceFirst(RegExp('^_'), '');
         final functionName = function.isStatic
-            ? '${function.enclosingElement.displayName}.$displayName'
+            ? '${function.enclosingElement2?.displayName}.$displayName'
             : displayName;
 
         customTransitionBuilder = ResolvedType(
           name: functionName,
-          import: function.source.uri.toString(),
+          import: function.firstFragment.libraryFragment.source.uri.toString(),
         );
       }
 

--- a/lib/src/generators/router/stacked_router_generator.dart
+++ b/lib/src/generators/router/stacked_router_generator.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:build/build.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:stacked_shared/stacked_shared.dart';
@@ -12,7 +12,7 @@ import 'generator/router_generator.dart';
 class StackedNavigatorGenerator extends GeneratorForAnnotation<StackedApp> {
   @override
   FutureOr<String> generateForAnnotatedElement(
-    Element element,
+    Element2 element,
     ConstantReader annotation,
     BuildStep buildStep,
   ) async {
@@ -20,7 +20,7 @@ class StackedNavigatorGenerator extends GeneratorForAnnotation<StackedApp> {
     final typeResolver = TypeResolver(libs);
 
     final routerConfig = RouterConfigResolver(typeResolver)
-        .resolve(annotation, element as ClassElement);
+        .resolve(annotation, element as ClassElement2);
 
     return RouterGenerator(routerConfig).generate();
   }

--- a/lib/src/generators/router_2/auto_route_generator.dart
+++ b/lib/src/generators/router_2/auto_route_generator.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:build/build.dart';
 import 'package:source_gen/source_gen.dart';
 // ignore: implementation_imports
@@ -27,18 +27,18 @@ class StackedRouterGenerator extends Generator {
   }
 
   dynamic generateForAnnotatedElement(
-    Element element,
+    Element2 element,
     ConstantReader annotation,
     BuildStep buildStep,
   ) async {
     // throw if annotation is used for a none class element
     throwIf(
-      element is! ClassElement,
-      '${element.name} is not a class element',
+      element is! ClassElement2,
+      '${element.name3} is not a class element',
       element: element,
     );
 
-    final clazz = element as ClassElement;
+    final clazz = element as ClassElement2;
     final usesPartBuilder = _hasPartDirective(clazz);
 
     final TypeResolver typeResolver;
@@ -49,7 +49,7 @@ class StackedRouterGenerator extends Generator {
       var libs = await buildStep.resolver.libraries.toList();
       Uri? targetFileUri;
       if (annotation.peek('preferRelativeImports')?.boolValue != false) {
-        targetFileUri = element.source.uri;
+        targetFileUri = element.firstFragment.libraryFragment.source.uri;
       }
       typeResolver = TypeResolver(libs, targetFileUri);
     }
@@ -69,13 +69,14 @@ class StackedRouterGenerator extends Generator {
     );
   }
 
-  bool _hasPartDirective(ClassElement clazz) {
-    final fileName = clazz.source.uri.pathSegments.last;
+  bool _hasPartDirective(ClassElement2 clazz) {
+    final fileName =
+        clazz.firstFragment.libraryFragment.source.uri.pathSegments.last;
     final part = fileName.replaceAll(
       '.dart',
       '.gr.dart',
     );
-    return clazz.library.parts.any(
+    return clazz.library2.fragments.any(
       (e) => e.toString().endsWith(part),
     );
   }

--- a/lib/src/generators/router_2/code_builder/library_builder.dart
+++ b/lib/src/generators/router_2/code_builder/library_builder.dart
@@ -33,7 +33,8 @@ String generateLibrary(
   throwIf(config.element == null,
       'Element is required for the Navigator2 Router. Something is broken');
 
-  final fileName = config.element!.source.uri.pathSegments.last;
+  final fileName = config
+      .element!.firstFragment.libraryFragment.source.uri.pathSegments.last;
 
   throwIf(
     usesPartBuilder && deferredLoading,
@@ -115,5 +116,6 @@ String generateLibrary(
       ]),
   );
 
-  return DartFormatter().format(library.accept(emitter).toString());
+  return DartFormatter(languageVersion: DartFormatter.latestLanguageVersion)
+      .format(library.accept(emitter).toString());
 }

--- a/lib/src/generators/router_2/resolvers/route_config_resolver.dart
+++ b/lib/src/generators/router_2/resolvers/route_config_resolver.dart
@@ -1,9 +1,9 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:source_gen/source_gen.dart';
-import 'package:stacked_shared/stacked_shared.dart';
 import 'package:stacked_generator/src/generators/extensions/string_utils_extension.dart';
 import 'package:stacked_generator/utils.dart';
+import 'package:stacked_shared/stacked_shared.dart';
 
 import '../../router_common/models/importable_type.dart';
 import '../../router_common/models/route_config.dart';
@@ -69,17 +69,17 @@ class RouteConfigResolver {
     }
 
     throwIf(
-      page.element is! ClassElement,
-      '${page.getDisplayString(withNullability: false)} is not a class element',
-      element: page.element,
+      page.element3 is! ClassElement2,
+      '${page.getDisplayString()} is not a class element',
+      element: page.element3,
     );
 
-    final classElement = page.element as ClassElement;
+    final classElement = page.element3 as ClassElement2;
     final import = _typeResolver.resolveImport(classElement);
-    final hasWrappedRoute = classElement.allSupertypes.any((e) =>
-        e.getDisplayString(withNullability: false) == 'AutoRouteWrapper');
+    final hasWrappedRoute = classElement.allSupertypes
+        .any((e) => e.getDisplayString() == 'AutoRouteWrapper');
     var pageType = _typeResolver.resolveType(page);
-    var className = page.getDisplayString(withNullability: false);
+    var className = page.getDisplayString();
 
     if (path == null) {
       var prefix = _routerConfig.parent != null ? '' : '/';
@@ -152,14 +152,14 @@ class RouteConfigResolver {
       final function = stackedRoute
           .peek('transitionsBuilder')
           ?.objectValue
-          .toFunctionValue();
+          .toFunctionValue2();
       if (function != null) {
         transitionBuilder = _typeResolver.resolveFunctionType(function);
       }
       final builderFunction = stackedRoute
           .peek('customRouteBuilder')
           ?.objectValue
-          .toFunctionValue();
+          .toFunctionValue2();
       if (builderFunction != null) {
         customRouteBuilder = _typeResolver.resolveFunctionType(builderFunction);
       }
@@ -185,8 +185,7 @@ class RouteConfigResolver {
         .mapValue
         .entries
         .where((e) => e.value?.type != null)) {
-      final valueType =
-          entry.value!.type!.getDisplayString(withNullability: false);
+      final valueType = entry.value!.type!.getDisplayString();
       throwIf(!validMetaValues.contains(valueType),
           'Meta value type $valueType is not supported!\nSupported types are $validMetaValues');
       switch (valueType) {
@@ -235,22 +234,22 @@ class RouteConfigResolver {
 
     var replacementInRouteName = _routerConfig.replaceInRouteName;
 
-    final constructor = classElement.unnamedConstructor;
+    final constructor = classElement.unnamedConstructor2;
     throwIf(
       constructor == null,
       'Route widgets must have an unnamed constructor',
     );
     var hasConstConstructor = false;
-    var params = constructor!.parameters;
+    var params = constructor!.formalParameters;
     var parameters = <ParamConfig>[];
     if (params.isNotEmpty == true) {
       if (constructor.isConst &&
           params.length == 1 &&
-          params.first.type.getDisplayString(withNullability: false) == 'Key') {
+          params.first.type.getDisplayString() == 'Key') {
         hasConstConstructor = true;
       } else {
         final paramResolver = RouteParameterResolver(_typeResolver);
-        for (ParameterElement p in constructor.parameters) {
+        for (FormalParameterElement p in constructor.formalParameters) {
           parameters.add(paramResolver.resolve(
             p,
             pathParams: pathParams,

--- a/lib/src/generators/router_2/resolvers/router_config_resolver.dart
+++ b/lib/src/generators/router_2/resolvers/router_config_resolver.dart
@@ -1,9 +1,9 @@
 import 'package:analyzer/dart/constant/value.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:source_gen/source_gen.dart';
-import 'package:stacked_shared/stacked_shared.dart';
 import 'package:stacked_generator/src/generators/router_common/models/route_parameter_config.dart';
 import 'package:stacked_generator/utils.dart';
+import 'package:stacked_shared/stacked_shared.dart';
 
 import '../../router_common/models/importable_type.dart';
 import '../../router_common/models/route_config.dart';
@@ -21,7 +21,7 @@ class RouterConfigResolver {
 
   RouterConfig resolve(
     ConstantReader stackedApp,
-    ClassElement clazz, {
+    ClassElement2 clazz, {
     bool usesPartBuilder = false,
   }) {
     int routeType = RouteType.material;
@@ -48,12 +48,12 @@ class RouterConfigResolver {
       customRouteBarrierDismissible =
           stackedApp.peek('barrierDismissible')?.boolValue;
       final function =
-          stackedApp.peek('transitionsBuilder')?.objectValue.toFunctionValue();
+          stackedApp.peek('transitionsBuilder')?.objectValue.toFunctionValue2();
       if (function != null) {
         transitionBuilder = _typeResolver.resolveFunctionType(function);
       }
       final customRouteBuilderValue =
-          stackedApp.peek('customRouteBuilder')?.objectValue.toFunctionValue();
+          stackedApp.peek('customRouteBuilder')?.objectValue.toFunctionValue2();
       if (customRouteBuilderValue != null) {
         customRouteBuilder =
             _typeResolver.resolveFunctionType(customRouteBuilderValue);

--- a/lib/src/generators/router_common/models/route_parameter_config.dart
+++ b/lib/src/generators/router_common/models/route_parameter_config.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element.dart' show ParameterElement;
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:code_builder/code_builder.dart' as code;
 
 import 'importable_type.dart';
@@ -29,7 +29,7 @@ class ParamConfig {
   final bool isPathParam;
   final bool isQueryParam;
   final String? defaultValueCode;
-  final ParameterElement? element;
+  final FormalParameterElement? element;
   final bool isInheritedPathParam;
 
   ParamConfig({

--- a/lib/src/generators/router_common/models/router_config.dart
+++ b/lib/src/generators/router_common/models/router_config.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element.dart' show ClassElement;
+import 'package:analyzer/dart/element/element2.dart';
 
 import 'route_config.dart';
 
@@ -11,7 +11,7 @@ class RouterConfig {
   final String routerClassName;
   final RouterConfig? parent;
   final String? replaceInRouteName;
-  final ClassElement? element;
+  final ClassElement2? element;
   final bool deferredLoading;
 
   RouterConfig({
@@ -36,7 +36,7 @@ class RouterConfig {
     String? routerClassName,
     RouterConfig? parent,
     String? replaceInRouteName,
-    ClassElement? element,
+    ClassElement2? element,
     bool? deferredLoading,
   }) {
     return RouterConfig(

--- a/lib/src/generators/router_common/resolvers/route_parameter_resolver.dart
+++ b/lib/src/generators/router_common/resolvers/route_parameter_resolver.dart
@@ -1,10 +1,10 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:source_gen/source_gen.dart';
-import 'package:stacked_shared/stacked_shared.dart';
 import 'package:stacked_generator/src/generators/router_common/models/route_parameter_config.dart';
 import 'package:stacked_generator/src/generators/router_common/resolvers/type_resolver.dart';
 import 'package:stacked_generator/utils.dart';
+import 'package:stacked_shared/stacked_shared.dart';
 
 const _pathParamChecker = TypeChecker.fromRuntime(PathParam);
 const _queryParamChecker = TypeChecker.fromRuntime(QueryParam);
@@ -15,7 +15,7 @@ class RouteParameterResolver {
   RouteParameterResolver(this._typeResolver);
 
   ParamConfig resolve(
-    ParameterElement parameterElement, {
+    FormalParameterElement parameterElement, {
     List<PathParamConfig> pathParams = const [],
     List<PathParamConfig> inheritedPathParams = const [],
   }) {
@@ -24,7 +24,7 @@ class RouteParameterResolver {
       return _resolveFunctionType(parameterElement);
     }
     var type = _typeResolver.resolveType(paramType);
-    final paramName = parameterElement.name.replaceFirst("_", '');
+    final paramName = parameterElement.name3?.replaceFirst("_", '');
     var pathParamAnnotation =
         _pathParamChecker.firstAnnotationOfExact(parameterElement);
     String? paramAlias;
@@ -54,17 +54,17 @@ class RouteParameterResolver {
 
     throwIf(
       pathParamAnnotation != null && queryParamAnnotation != null,
-      '${parameterElement.name} can not be both a pathParam and a queryParam!',
+      '${parameterElement.name3} can not be both a pathParam and a queryParam!',
       element: parameterElement,
     );
 
     return ParamConfig(
       type: type,
       element: parameterElement,
-      name: paramName,
+      name: paramName!,
       alias: paramAlias,
       isPositional: parameterElement.isPositional,
-      hasRequired: parameterElement.hasRequired,
+      hasRequired: parameterElement.isRequired,
       isRequired: parameterElement.isRequiredNamed,
       isOptional: parameterElement.isOptional,
       isNamed: parameterElement.isNamed,
@@ -76,20 +76,21 @@ class RouteParameterResolver {
     );
   }
 
-  ParamConfig _resolveFunctionType(ParameterElement paramElement) {
+  ParamConfig _resolveFunctionType(FormalParameterElement paramElement) {
     var type = paramElement.type as FunctionType;
     return FunctionParamConfig(
-        returnType: _typeResolver.resolveType(type.returnType),
-        type: _typeResolver.resolveType(type),
-        params: type.parameters.map(resolve).toList(),
-        element: paramElement,
-        name: paramElement.name,
-        defaultValueCode: paramElement.defaultValueCode,
-        isRequired: paramElement.isRequiredNamed,
-        isPositional: paramElement.isPositional,
-        hasRequired: paramElement.hasRequired,
-        isOptional: paramElement.isOptional,
-        isNamed: paramElement.isNamed);
+      returnType: _typeResolver.resolveType(type.returnType),
+      type: _typeResolver.resolveType(type),
+      params: type.formalParameters.map(resolve).toList(),
+      element: paramElement,
+      name: paramElement.name3!,
+      defaultValueCode: paramElement.defaultValueCode,
+      isRequired: paramElement.isRequiredNamed,
+      isPositional: paramElement.isPositional,
+      hasRequired: paramElement.isRequired,
+      isOptional: paramElement.isOptional,
+      isNamed: paramElement.isNamed,
+    );
   }
 
   static List<PathParamConfig> extractPathParams(String path) {

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -1,12 +1,12 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:stacked_generator/src/generators/exceptions/invalid_generator_input_exception.dart';
 import 'package:stacked_generator/src/generators/router_common/models/route_parameter_config.dart';
 import 'package:stacked_generator/src/helpers/config_helper.dart';
 import 'package:stacked_generator/src/helpers/file_helper.dart';
 
-String toDisplayString(DartType e, {bool withNullability = false}) {
-  return e.getDisplayString(withNullability: withNullability);
+String toDisplayString(DartType e) {
+  return e.getDisplayString();
 }
 
 String processedReturnType(String? returnType) {
@@ -27,13 +27,13 @@ String processedReturnType(String? returnType) {
 }
 
 void throwIf(bool condition, String message,
-    {Element? element, String todo = ''}) {
+    {Element2? element, String todo = ''}) {
   if (condition) {
     throwError(message, todo: todo, element: element);
   }
 }
 
-void throwError(String message, {Element? element, String todo = ''}) {
+void throwError(String message, {Element2? element, String todo = ''}) {
   throw InvalidGeneratorInputException(
     message,
     todo: todo,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,33 +1,33 @@
 name: stacked_generator
 description: Stacked Generator is a package dedicated to reduce the boilerplate required to setup a stacked application
-version: 1.6.0
+version: 1.7.0
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_generator
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  build: ^2.2.1
-  path: ^1.8.0
-  recase: ^4.0.0
-  source_gen: ^1.2.7
-  meta: ^1.10.0
-  logger: ^2.0.1
-  stacked_shared: ^1.3.0
+  build: ^3.0.0
+  path: ^1.9.1
+  recase: ^4.1.0
+  source_gen: ^3.0.0
+  meta: ^1.16.0
+  logger: ^2.6.0
+  stacked_shared: ^1.4.2
   # Removing this will cause issues when publish the package
-  analyzer: ^6.3.0
-  dart_style: ^2.3.4
-  code_builder: ^4.3.0
-  collection: ^1.16.0
-  freezed_annotation: ^2.2.0
-  json_annotation: ^4.8.0
-  xdg_directories: ^1.0.4
+  analyzer: ^7.5.5
+  dart_style: ^3.1.0
+  code_builder: ^4.10.1
+  collection: ^1.19.1
+  freezed_annotation: ^3.1.0
+  json_annotation: ^4.9.0
+  xdg_directories: ^1.1.0
 
 dev_dependencies:
-  build_runner: ^2.0.6
-  test: ^1.20.1
-  build_test: ^2.1.5
-  flutter_lints: ^3.0.1
-  freezed: ^2.3.2
-  json_serializable: ^6.6.1
-  mockito: ^5.4.4
+  build_runner: ^2.5.4
+  test: ^1.26.2
+  build_test: ^3.2.1
+  flutter_lints: ^6.0.0
+  freezed: ^3.2.0
+  json_serializable: ^6.9.5
+  mockito: ^5.4.6

--- a/test/bottomsheets/bottomsheet_class_generator_test.dart
+++ b/test/bottomsheets/bottomsheet_class_generator_test.dart
@@ -7,23 +7,23 @@ import '../helpers/test_constants/bottomsheets_constants.dart';
 void main() {
   group('BottomsheetClassGeneratorTest -', () {
     group('generate -', () {
-      test('When empty', () {
+      test('When empty', () async {
         final generator = BottomsheetClassGenerator([]);
-        expect(generator.generate(), kBottomsheetsEmpty);
+        expect(await generator.generate(), kBottomsheetsEmpty);
       });
-      test('When change locator name', () {
+      test('When change locator name', () async {
         final generator =
             BottomsheetClassGenerator([], locatorName: 'customLocator');
-        expect(generator.generate(), kBottomsheetsWithCustomNamedLocator);
+        expect(await generator.generate(), kBottomsheetsWithCustomNamedLocator);
       });
-      test('One bottomsheet', () {
+      test('One bottomsheet', () async {
         final generator = BottomsheetClassGenerator([
           const BottomsheetConfig(
               import: 'one.dart', bottomsheetClassName: 'BasicBottomsheet')
         ]);
-        expect(generator.generate(), kOneBottomsheet);
+        expect(await generator.generate(), kOneBottomsheet);
       });
-      test('Two bottomsheets', () {
+      test('Two bottomsheets', () async {
         final generator = BottomsheetClassGenerator([
           const BottomsheetConfig(
               import: 'one.dart', bottomsheetClassName: 'BasicBottomsheet'),
@@ -31,7 +31,7 @@ void main() {
               import: 'two.dart', bottomsheetClassName: 'ComplexBottomsheet')
         ]);
 
-        expect(generator.generate(), kTwoBottomsheets);
+        expect(await generator.generate(), kTwoBottomsheets);
       });
     });
   });

--- a/test/dialogs/dialog_class_generator_test.dart
+++ b/test/dialogs/dialog_class_generator_test.dart
@@ -7,22 +7,22 @@ import '../helpers/test_constants/dialog_constant.dart';
 void main() {
   group('DialogClassGeneratorTest -', () {
     group('generate -', () {
-      test('When empty', () {
+      test('When empty', () async {
         final generator = DialogClassGenerator([]);
-        expect(generator.generate(), kDialogsEmpty);
+        expect(await generator.generate(), kDialogsEmpty);
       });
-      test('When change locator name', () {
+      test('When change locator name', () async {
         final generator =
             DialogClassGenerator([], locatorName: 'customLocator');
-        expect(generator.generate(), kDialogsWithCustomNamedLocator);
+        expect(await generator.generate(), kDialogsWithCustomNamedLocator);
       });
-      test('One dialog', () {
+      test('One dialog', () async {
         final generator = DialogClassGenerator([
           const DialogConfig(import: 'one.dart', dialogClassName: 'BasicDialog')
         ]);
-        expect(generator.generate(), kOneDialog);
+        expect(await generator.generate(), kOneDialog);
       });
-      test('Two dialogs', () {
+      test('Two dialogs', () async {
         final generator = DialogClassGenerator([
           const DialogConfig(
               import: 'one.dart', dialogClassName: 'BasicDialog'),
@@ -30,7 +30,7 @@ void main() {
               import: 'two.dart', dialogClassName: 'ComplexDialog')
         ]);
 
-        expect(generator.generate(), kTwoDialogs);
+        expect(await generator.generate(), kTwoDialogs);
       });
     });
   });

--- a/test/helpers/class_extension.dart
+++ b/test/helpers/class_extension.dart
@@ -6,7 +6,9 @@ extension SpecExtension on Spec {
     final library = Library((b) => b..body.add(this));
 
     final emitter = DartEmitter.scoped();
-    final result = DartFormatter().format('${library.accept(emitter)}');
+    final result =
+        DartFormatter(languageVersion: DartFormatter.latestLanguageVersion)
+            .format('${library.accept(emitter)}');
     //print(result);
     return result;
   }
@@ -17,7 +19,9 @@ extension SpecsExtension on Iterable<Spec> {
     final library = Library((b) => b..body.addAll(this));
 
     final emitter = DartEmitter.scoped();
-    final result = DartFormatter().format('${library.accept(emitter)}');
+    final result =
+        DartFormatter(languageVersion: DartFormatter.latestLanguageVersion)
+            .format('${library.accept(emitter)}');
 
     return result;
   }
@@ -28,7 +32,9 @@ extension ListExpressionExtension on Iterable<Expression> {
     final library = Library((b) => b..body.addAll(this));
 
     final emitter = DartEmitter.scoped();
-    final result = DartFormatter().format('${library.accept(emitter)}');
+    final result =
+        DartFormatter(languageVersion: DartFormatter.latestLanguageVersion)
+            .format('${library.accept(emitter)}');
 
     return result;
   }

--- a/test/helpers/common.dart
+++ b/test/helpers/common.dart
@@ -47,7 +47,9 @@ Future<void> checkCodeForCompilationError(
     },
     (r) => r.libraries.firstWhere((element) {
       /// [element.source.toString()] will print the name of the file for example 'test.dart'
-      return element.source.toString().contains(fileName);
+      return element.firstFragment.libraryFragment!.source
+          .toString()
+          .contains(fileName);
     }),
   );
 

--- a/test/helpers/test_constants/logger_constants.dart
+++ b/test/helpers/test_constants/logger_constants.dart
@@ -1,9 +1,9 @@
 const String kloggerClassContent = """
 // ignore_for_file: avoid_print, depend_on_referenced_packages
 
-/// Maybe this should be generated for the user as well?
-///
-/// import 'package:customer_app/services/stackdriver/stackdriver_service.dart';
+// Maybe this should be generated for the user as well?
+//
+// import 'package:customer_app/services/stackdriver/stackdriver_service.dart';
 import 'package:flutter/foundation.dart';
 import 'package:logger/logger.dart';
 
@@ -28,10 +28,15 @@ class SimpleLogPrinter extends LogPrinter {
     this.showOnlyClass,
   });
 
+
+  final printer = PrettyPrinter(
+    levelColors: PrettyPrinter.defaultLevelColors,
+    levelEmojis: PrettyPrinter.defaultLevelEmojis,
+  );
   @override
   List<String> log(LogEvent event) {
-    var color = PrettyPrinter.defaultLevelColors[event.level];
-    var emoji = PrettyPrinter.defaultLevelEmojis[event.level];
+    var color = printer.levelColors?[event.level];
+    var emoji = printer.levelEmojis?[event.level];
     var methodName = _getMethodName();
 
     var methodNameSection =
@@ -40,9 +45,12 @@ class SimpleLogPrinter extends LogPrinter {
     var output =
         '\$emoji \$className\$methodNameSection - \${event.message}\${event.error != null ? '\\nERROR: \${event.error}\\n' : ''}\${printCallStack ? '\\nSTACKTRACE:\\n\$stackLog' : ''}';
 
-    if (exludeLogsFromClasses
-            .any((excludeClass) => className == excludeClass) ||
-        (showOnlyClass != null && className != showOnlyClass)) return [];
+    if (exludeLogsFromClasses.any(
+          (excludeClass) => className == excludeClass,
+        ) ||
+        (showOnlyClass != null && className != showOnlyClass)) {
+      return [];
+    }
 
     final pattern = RegExp('.{1,800}'); // 800 is the size of each chunk
     List<String> result = [];
@@ -192,8 +200,8 @@ class SimpleLogPrinter extends LogPrinter {
 
   @override
   List<String> log(LogEvent event) {
-    var color = PrettyPrinter.defaultLevelColors[event.level];
-    var emoji = PrettyPrinter.defaultLevelEmojis[event.level];
+    var color = PrettyPrinter.levelColors[event.level];
+    var emoji = PrettyPrinter.levelEmojis[event.level];
     var methodName = _getMethodName();
 
     var methodNameSection =
@@ -315,7 +323,7 @@ Logger ebraLogger(
       exludeLogsFromClasses: exludeLogsFromClasses,
     ),
     output: MultiOutput([
-      
+
       ConsoleOutput(),
        if(kReleaseMode) outputOne(), if(kReleaseMode) outputTwo(),
     ]),
@@ -368,7 +376,7 @@ Logger ebraLogger(
       exludeLogsFromClasses: exludeLogsFromClasses,
     ),
     output: MultipleLoggerOutput([
-      
+
       ConsoleOutput(),
        if(kReleaseMode) outputOne(), if(kReleaseMode) outputTwo(),
     ]),
@@ -409,7 +417,7 @@ Logger getLogger(
     output: MultiOutput([
       if(!kReleaseMode)
       ConsoleOutput(),
-      
+
     ]),
   );
 }


### PR DESCRIPTION
Summary

  - Migrate all code generators from deprecated Element API to Element2 API for Dart analyzer compatibility
  - Update dependencies to support newer analyzer versions
  - Fix form validation logic and conditional code generation patterns
  - Modernize DartFormatter usage across all generators

  What Changed

  API Migration

  - Element → Element2: Updated all generator classes to use the new Element2 API
  - Property Access: Migrated from element.source to element.firstFragment.libraryFragment.source patterns
  - Type Resolution: Updated from element to element3 and toFunctionValue() to toFunctionValue2()
  - Import Updates: Changed imports from analyzer/dart/element/element.dart to element2.dart

  Affected Generators

  - Router Generator - Both legacy and Navigator 2.0 implementations
  - Dependency Injection - GetIt locator generation
  - Forms Generator - Form validation and controller management
  - Logging Generator - Logger setup and configuration
  - Dialog & Bottomsheet Generators - UI component management

  Improvements

  - Fixed form validation setter return types (void instead of String?)
  - Enhanced conditional code generation for text field validation
  - Updated DartFormatter to use latestLanguageVersion
  - Modernized logger printer implementation with proper null safety

  Dependencies

  - Updated analyzer constraints to support version 7.7.1
  - Maintained backward compatibility with existing generated code

  Breaking Changes

  ⚠️ None - This is an internal API migration that maintains the same public interface and generated code output.