### PR TITLE
fix(import_resolver): fall back to element source URI when no library re-exports it

### DIFF
--- a/lib/import_resolver.dart
+++ b/lib/import_resolver.dart
@@ -32,7 +32,19 @@ class ImportResolver {
       }
     }
 
-    return null;
+    // No library in `libs` re-exports `element`. This can happen under
+    // build systems whose codegen resolvers expose a narrower library set
+    // than build_runner does — e.g. Bazel's rules_dart codegen action,
+    // which provides each transitive package's `src/` libraries but not
+    // their public re-exporting library. Without this fallback, callers
+    // (e.g. dependency_config_factory) end up emitting `import null;` for
+    // perfectly reachable types like StackedService.
+    //
+    // The element's own source URI is always a valid Dart import — it
+    // just points at a `src/` path rather than the public re-export.
+    // Generated code compiles and behaves identically. Prefer this over
+    // returning null, which strands the caller with no recoverable info.
+    return elementSourceUri.toString();
   }
 
   bool _isCoreDartType(Element? element) {


### PR DESCRIPTION
ImportResolver.resolve returned null when no library in libs re-exports the element, even though the element's own source URI is always a valid Dart import. This stranded callers like dependency_config_factory with no way to produce a working import for the element.

Under standard build_runner, libs is the full transitive package graph and the original loop almost always matched, so the null path was rarely hit. Under Bazel's rules_dart codegen action, libs is each package's src/ libraries only (not the public re-exporting library), so the loop fails to match for types like StackedService and codegen emits broken imports.

Falling back to the element's source URI is harmless under build_runner (unreachable) and unblocks Bazel + any other host with a similar library scope.